### PR TITLE
A completion fix and a bunch of stylistic changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ Verify pgp signatures and show the result in the timeline if set to 1. Defaults 
 
 ### ipfs_gateway
 
-When you subscribe to a ipns:// address, txtnish will call this gateway to get
-the users twtfile. Defaults to http://localhost:8080 and falls back to
-https://ipfs.io if txtnish can't reach the gateway.
+When you subscribe to an `ipns://` address, txtnish will call this gateway to get
+the users twtfile. Defaults to `http://localhost:8080` and falls back to
+`https://ipfs.io` if txtnish can't reach the gateway.
 
 ## Publish with scp
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Removes an existing source from your followings.
 
 ## following
 
-Print the list of the sources you're following.
+Prints the list of the sources you're following.
 
 ## reply
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ to zero.
 
 ### use_color
 
-If the output should be colorized with ansi escape sequences. See the
-section *COLORS* how to change the color settings. Default to 1.
+If the output should be colorized with ANSI escape sequences. See the
+section *COLORS* on how to change the color settings. Default to 1.
 
 ### pager
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ $ txtnish quickstart
 
 # Installation
 
-*txtnish* only depends on tools you normally find in a posix environment:
-awk, sort, cut and sh. There are only two exceptions: you need curl
-to download twtxt files and a xargs that support parallel processing
-via *-P*. You can use a xargs without, but then txtnish falls back to
+*txtnish* only depends on tools you normally find in a POSIX environment:
+*awk*, *sort*, *cut* and *sh*. There are only two exceptions: you need *curl*
+to download twtxt files and a *xargs* that support parallel processing
+via *-P*. You can use a *xargs* without, but then *txtnish* falls back to
 downloading one url after another.
 
 Installation itself is as easy as it gets: just copy the script somewhere

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Call `ipfs add` with `--wrap-with-dir` if set to 1. Defaults to 0.
 
 ### ipfs_recursive
 
-Call ipfs add with --recursive if set to 1. The complete directory of
+Call `ipfs add` with `--recursive` if set to 1. The complete directory of
 your twtfile will be published. Defaults to 0.
 
 ## Colors

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ be tweeted.
 # Search tweets
 
 You can provide a search expression to filter your timeline with the flag
-`-S`. The search expression is a awk conditional with four predefined
+`-S`. The search expression is an *awk* conditional with four predefined
 variables:
 
 * msg: the message itself

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ your unique timeline out of them, depending on which files you track. The
 format is simple, human readable, and integrates well with UNIX command line
 utilities.
 
-All subcommand of *txtnish* provides extensive help, so don't hesitate
+All subcommands of *txtnish* provide extensive help, so don't hesitate
 to call them with the `-h` option.
 
 If you are a new user, there is a quickstart command that will ask you some

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ txtnish timeline -S 'nick == "mdom" && msg ~ /#twtxt/'
 
 # Configuration
 
-At startup txtnish checks for `~/.config/txtnish/config` exists and
-will source it if is exists. The configuration file must be a valid
+At startup txtnish checks whether `~/.config/txtnish/config` exists and
+will source it if it exists. The configuration file must be a valid
 shell script.
 
 ## General

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ color_hashtag=yellow
 
 ## Hooks
 
-To customize the behaviour of txtnish the user can override functions.
+To customize the behaviour of *txtnish* the user can override functions.
 
 ### pre_tweet_hook
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ $ txtnish quickstart
 # Installation
 
 *txtnish* only depends on tools you normally find in a posix environment:
-awk, sort, cut and sh. There are only two exceptions: You need curl
+awk, sort, cut and sh. There are only two exceptions: you need curl
 to download twtxt files and a xargs that support parallel processing
 via *-P*. You can use a xargs without, but then txtnish falls back to
 downloading one url after another.
 
-Installation itself is as easy as it gets: Just copy the script somewhere
+Installation itself is as easy as it gets: just copy the script somewhere
 in your *PATH*.
 
 # Subcommands

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ section *COLORS* on how to change the color settings. Default to 1.
 
 ### pager
 
-Which pager to use if use_pager is enabled. Default to `less -R` in order
+Which pager to use if `use_pager` is enabled. Default to `less -R` in order
 to display colors. This can be toggled with `-p` or `-P` to enable or
 disable  the pager. Defaults to 1.
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ You will need the ipfs tools and a running daemon to publish to ipfs.
 
 ### ipfs_wrap_with_dir
 
-Call ipfs add with --wrap-with-dir if set to 1. Defaults to 0.
+Call `ipfs add` with `--wrap-with-dir` if set to 1. Defaults to 0.
 
 ### ipfs_recursive
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ $ txtnish timeline
 
 # Description
 
-*txtnish* is a client for [twtxt](https://github.com/buckket/twtxt)
-the decentralised, minimalist microblogging service for hackers.
+*txtnish* is a client for [twtxt](https://github.com/buckket/twtxt)–the 
+decentralised, minimalist microblogging service for hackers.
 
 Instead of signing up at a closed and/or regulated microblogging platform,
 getting your status updates out with twtxt is as easy as putting them in a

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Appends a new tweet to your twtxt file. There are three different ways
 to input tweets. You can either pipe them into tweet, or pass them along
 as arguments. When you call `txtnish tweet` without any arguments and
 it's not connected to a pipe, it will call `$EDITOR` for you and tweet
-any line as seperate tweet.
+any line as a separate tweet.
 
 ## timeline
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ to zero.
 ### use_color
 
 If the output should be colorized with ANSI escape sequences. See the
-section *COLORS* on how to change the color settings. Default to 1.
+section *COLORS* on how to change the color settings. Defaults to 1.
 
 ### pager
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ shell script.
 
 ### limit
 
-How many tweets should be shown in timeline. Default to 20.
+How many tweets should be shown in timeline. Defaults to 20.
 
 ### formatter
 

--- a/completions/_txtnish
+++ b/completions/_txtnish
@@ -31,5 +31,6 @@ _alternative 'args:custom args:((\
 		url\:"Share urls" \
 		-h\:"Print a help message and exit" \
 		-V\:"Print version and exit"))' \
-		"files:filenames:($(/bin/ls ~/.cache/txtnish/twtfiles | sed 's/.txt//g'))"
+		"files:filenames:($([ -d ${HOME}/.cache/txtnish/twtfiles ] && /bin/ls \
+		 ~/.cache/txtnish/twtfiles | sed 's/.txt//g'))"
 


### PR DESCRIPTION
I initially wanted just to fix the zsh completion (the completion didn't check whether there were twtfiles or not), but then I started to fix README... and now there are 16 commits with stylistic and grammar fixes. Sorry for this. 😃

zsh now doesn't warn the user if he/she uses the completion without running *txtnish* for the first time.