### PR TITLE
Add - to regexp for coloring nicknames and hashtags

### DIFF
--- a/bin/txtnish
+++ b/bin/txtnish
@@ -354,8 +354,8 @@ format_msg () {
 
 			nick = color_nick nick reset
 			ts = color_time ts reset
-			gsub(/#[[:alnum:]_]+/, color_hashtag "&" reset, msg)
-			gsub(/@[[:alnum:]_]+/, color_mention "&" reset, msg)
+			gsub(/#[[:alnum:]_-]+/, color_hashtag "&" reset, msg)
+			gsub(/@[[:alnum:]_-]+/, color_mention "&" reset, msg)
 		}
 		fmt = ENVIRON["formatter"]
 		printf "* %s (%s)", nick, ts


### PR DESCRIPTION
I have choosen 'C-Keen' as my nickname and it should get colored as a whole. Thus I added '-' to the regexps to allow this.

I am not sure whether this breaks any other usage of '-' in messages.

So far I haven't seen any though.