### PR TITLE
Switchable gpg binary, local signing user override and SFTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,16 @@ a *TAB* are not allowed by a strict reading of the spec.
 
 Verify pgp signatures and show the result in the timeline if set to 1. Defaults to 0.
 
+### sign_user
+
+Sets a different local user to sign twtfile than what is the default. It will
+print a message indicating an override is in place.
+
+### gpg_bin
+
+Set custom name of gpg executable, might be useful if your system defaults
+to the 1.x branch of gpg but keys you use or verify require gpg 2.x.
+
 ### ipfs_gateway
 
 When you subscribe to an `ipns://` address, txtnish will call this gateway to get
@@ -213,6 +223,11 @@ Copy twtfile to this host. Required to publish with scp.
 ### scp_remote_name
 
 Name of twtfile on remote host. Defaults to the basename of the twtfile.
+
+### sftp_over_scp
+
+Will use SFTP instead of SCP if set to 1, might be useful for the hosts
+that refuse SCP protocol access.
 
 ## Publish with ftp
 

--- a/bin/txtnish
+++ b/bin/txtnish
@@ -24,6 +24,8 @@ color_nick=yellow
 color_time=blue
 color_hashtag=cyan
 color_mention=yellow
+gpg_bin=${gpg_bin:-gpg}
+sign_user=""
 sign_twtfile=0
 check_signatures=0
 ipfs_publish=0
@@ -46,6 +48,7 @@ https_proxy=""
 ftp_user=""
 ftp_host=""
 
+sftp_over_scp=0
 scp_user=""
 scp_host=""
 
@@ -562,7 +565,7 @@ normalize_tweets () {
 }
 
 gpg_verify () {
-	gpg --status-fd=1 --no-verbose --quiet --batch --verify "$1" 2>/dev/null
+	$gpg_bin --status-fd=1 --no-verbose --quiet --batch --verify "$1" 2>/dev/null
 }
 
 collapse_mentions () {
@@ -1107,7 +1110,7 @@ timeline () {
 	maybe_update "$@";
 
 	have_gpg=0
-	if have_cmd gpg ;then
+	if have_cmd $gpg_bin ;then
 		have_gpg=1
 	fi
 
@@ -1172,7 +1175,7 @@ update_metadata () {
 		if [ "$sign_twtfile" -eq 1 ];then
 			gpgconf --list-options gpg \
 			| awk -F: '$1 == "default-key" {print substr($10,2)}' \
-			| xargs gpg --fingerprint \
+			| xargs $gpg_bin --fingerprint \
 			| awk '/Key fingerprint = / { print "# gpg_fingerprint = " substr($0,25) }'
 		fi
 		following | while read line; do printf "# following = %s\n" "$line" ;done
@@ -1199,19 +1202,32 @@ publish () {
 		fi
 	fi
 	if [ "$sign_twtfile" -eq 1 ];then
+		if [ -n "$sign_user" ]; then
+			signopt="-u $sign_user"
+			# for security, echo this
+			echo "Signing as $sign_user."
+		else
+			unset signopt
+		fi
 		if mkdir -p "$cache_dir/tmp.$$/";then
 			tempdir="$cache_dir/tmp.$$/"
 		else
 			die "Can't create temporary dir $tempdir"
 		fi
-		if gpg --clearsign --output "$tempdir/${twtfile##*/}" "$twtfile";then
+		if $gpg_bin --clearsign $signopt --output "$tempdir/${twtfile##*/}" "$twtfile";then
 			twtfile="$tempdir/${twtfile##*/}"
 		else
 			die "Can't sign twtfile. Exiting";
 		fi
 	fi
 	if [ -n "$scp_user" ] && [ -n "$scp_host" ];then
-		scp "$twtfile" "$scp_user@$scp_host:${scp_remote_name:-${twtfile##*/}}"
+		if [ $sftp_over_scp -eq 1 ]; then
+			sftp "$scp_user@$scp_host" <<-EOF
+				put "$twtfile" "${scp_remote_name:-${twtfile##*/}}"
+EOF
+		else
+			scp "$twtfile" "$scp_user@$scp_host:${scp_remote_name:-${twtfile##*/}}"
+		fi
 	fi
 	if [ -n "$ftp_user" ] && [ -n "$ftp_host" ];then
 		if curl -Ss -nT "$twtfile" "ftp://$ftp_user@$ftp_host/${ftp_remote_name:-${twtfile##*/}}";then


### PR DESCRIPTION
Hi. I made some changes that might be useful for systems bundling gpg 1.x and 2.x under different binary names, as well as added SFTP support (mostly because OVH absolutely refuses to have _anything_ to do with SCP). 