### PR TITLE
bin/txtnish: remove unnecessary create_dir()

### DIFF
--- a/bin/txtnish
+++ b/bin/txtnish
@@ -108,14 +108,6 @@ info () {
 	[ "$verbose" -gt 0 ] && printf "%s: %s\n" "$program_name" "$1"
 }
 
-# Description: Create dir unless it exists
-# Synopsis: create_dir DIR
-# Returns: nothing
-
-create_dir () {
-	[ -d "$1" ] || mkdir -p "$1"
-}
-
 # Description: Source configuration file if it exists
 # Synopsis: read_config
 # Returns: nothing
@@ -1416,7 +1408,7 @@ call_mode () {
 				;;
 			-h | --help )
 				check_if_valid_option help
-			       	usage
+				usage
 				;;
 			-p | -P | --pager | --no-pager )
 				check_if_valid_option pager
@@ -1588,11 +1580,11 @@ main() {
 
 	trap cleanup EXIT
 
-	create_dir "$config_dir"
-	create_dir "$cache_dir"
-	create_dir "$cache_dir/twtfiles"
-	create_dir "$cache_dir/timestamps"
-	create_dir "$log_dir"
+	mkdir -p "$config_dir"
+	mkdir -p "$cache_dir"
+	mkdir -p "$cache_dir/twtfiles"
+	mkdir -p "$cache_dir/timestamps"
+	mkdir -p "$log_dir"
 
 	if ! [ -e "$follow_file" ];then
 		:> "$follow_file"


### PR DESCRIPTION
`mkdir -p DIR` already checks if `DIR` exists and if so exits 0 so you don't really need `create_dir()`

(Also includes a small whitespace fix.)